### PR TITLE
cmd/internal: remove vanity import

### DIFF
--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -1,4 +1,4 @@
-package internal // import "go.fraixed.es/onepagestaticsite/cmd/internal"
+package internal
 
 import (
 	"fmt"


### PR DESCRIPTION
Because the internal package isn't accessible outside from the cmd
package, it doesn't need the vanity import, so it has been removed.