### PR TITLE
Restore Coveralls service in the CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
 
 script:
   - make ci
+  - if [ "$COVERAGE" = true ]; then goveralls -coverprofile=profile.cov -service=travis-ci; fi
 
 notifications:
   email: false


### PR DESCRIPTION
In the last refactoring of the CI configuration the Coveralls service
was removed, so this commit get it back.